### PR TITLE
Provide the seed in assertion failure messages

### DIFF
--- a/bananas/core/src/main/scala/com/meltwater/bananas/core/package.scala
+++ b/bananas/core/src/main/scala/com/meltwater/bananas/core/package.scala
@@ -42,6 +42,7 @@ package object core {
         .take(config.maxSamples)
         .compile
         .foldMonoid
+        .map(_.leftMap(_.map(_ + s" (seed: ${config.seed})")))
     }
   }
 


### PR DESCRIPTION
When rendering an assertion failure, we should show the seed that was
used in order to provide a means to reproduce the failure.